### PR TITLE
Switch to using the HTTPS endpoint

### DIFF
--- a/src/main/java/com/postmark/java/PostmarkClient.java
+++ b/src/main/java/com/postmark/java/PostmarkClient.java
@@ -165,7 +165,7 @@ public class PostmarkClient {
         try {
 
             // Create post request to Postmark API endpoint
-            HttpPost method = new HttpPost("http://api.postmarkapp.com/email");
+            HttpPost method = new HttpPost("https://api.postmarkapp.com/email");
 
             // Add standard headers required by Postmark
             method.addHeader("Accept", "application/json");


### PR DESCRIPTION
as recommended by the API reference overview.
